### PR TITLE
Fix broken reference links

### DIFF
--- a/ADFS StringProc Attribute Store/StringProcessingAttributeStore.cs
+++ b/ADFS StringProc Attribute Store/StringProcessingAttributeStore.cs
@@ -11,7 +11,7 @@ using System.IdentityModel;
  * The code started straight from Microsoft's example here:
  *    https://msdn.microsoft.com/en-us/library/hh599320.aspx
  * ...with assistance from this article:
- *    http://blogs.technet.com/b/cloudpfe/archive/2013/12/27/how-to-create-a-custom-attribute-store-for-active-directory-federation-services-3-0.aspx
+ *    https://learn.microsoft.com/en-us/archive/blogs/cloudpfe/how-to-create-a-custom-attribute-store-for-active-directory-federation-services-3-0
  * See those pages for details on compiling, installing, and using the DLL.
  * 
  * --Eric Wallace, March 2015

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The code was initially straight from Microsoft's example here:
 
 ...with assistance from this article:
 
-* [http://blogs.technet.com/b/cloudpfe/archive/2013/12/27/how-to-create-a-custom-attribute-store-for-active-directory-federation-services-3-0.aspx]()
+* [https://learn.microsoft.com/en-us/archive/blogs/cloudpfe/how-to-create-a-custom-attribute-store-for-active-directory-federation-services-3-0]()
 
 See those pages for details on compiling, installing, and using the DLL.
 


### PR DESCRIPTION
Microsoft Technet blogs have moved to learn.microsoft and they broke all the old links instead of forwarding them